### PR TITLE
Declare OS X and watchOS support in the podspec

### DIFF
--- a/AFDateHelper.podspec
+++ b/AFDateHelper.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/melvitax/AFDateHelper.git", :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/melvitax'
 
-  s.platforms     = { :ios => '8.0', :tvos => '9.0' }
+  s.platforms     = { :ios => '8.0', :tvos => '9.0', :osx => '10.10', :watchos => '2.0' }
   s.requires_arc = true
 
   s.source_files = 'AFDateHelper/**/*'

--- a/AFDateHelper.podspec
+++ b/AFDateHelper.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.license          = 'MIT'
   s.author           = { "Melvin Rivera" => "melvin@allforces.com" }
   s.source           = { :git => "https://github.com/melvitax/AFDateHelper.git", :tag => s.version.to_s }
-  # s.social_media_url = 'https://twitter.com/melvitax'
+  s.social_media_url = 'https://twitter.com/melvitax'
 
   s.platforms     = { :ios => '8.0', :tvos => '9.0', :osx => '10.10', :watchos => '2.0' }
 

--- a/AFDateHelper.podspec
+++ b/AFDateHelper.podspec
@@ -24,9 +24,4 @@ Pod::Spec.new do |s|
   s.platforms     = { :ios => '8.0', :tvos => '9.0', :osx => '10.10', :watchos => '2.0' }
 
   s.source_files = 'AFDateHelper/**/*'
-  #s.resource_bundles = {}
-
-  # s.public_header_files
-  # s.frameworks
-  # s.dependency 
 end

--- a/AFDateHelper.podspec
+++ b/AFDateHelper.podspec
@@ -22,7 +22,6 @@ Pod::Spec.new do |s|
   # s.social_media_url = 'https://twitter.com/melvitax'
 
   s.platforms     = { :ios => '8.0', :tvos => '9.0', :osx => '10.10', :watchos => '2.0' }
-  s.requires_arc = true
 
   s.source_files = 'AFDateHelper/**/*'
   #s.resource_bundles = {}


### PR DESCRIPTION
The pod can't be used currently via CocoaPods on OS X or watchOS while nothing would prevent the library to build on these platforms.
I tried to do a little clean up of the podspec as well and thought you might want to enable the `social_media_url`, so that when you push out a new version (which would be much appreciated), you will be mentioned with your Twitter handle in the automatic CocoaPods feed tweet.
