### PR TITLE
Updated the date adjustment for .endOfDay to 23:59:59

### DIFF
--- a/Sources/DateHelper.swift
+++ b/Sources/DateHelper.swift
@@ -357,7 +357,7 @@ public extension Date {
         case .startOfDay:
             return adjust(hour: 0, minute: 0, second: 0)
         case .endOfDay:
-            return adjust(hour: 23, minute: 59, second: 29)
+            return adjust(hour: 23, minute: 59, second: 59)
         case .startOfWeek:
             let offset = component(.weekday)!-1
             return adjust(.day, offset: -(offset))


### PR DESCRIPTION
I found the .endOfDay was adjusting the date to be 23:59:29 instead of 23:59:59, please let me know if the adjustment was intentional.

The fix was just a simple constant change in the second component parameter.