### PR TITLE
Added "default" option to TimeZoneType

### DIFF
--- a/Sources/DateHelper.swift
+++ b/Sources/DateHelper.swift
@@ -616,7 +616,7 @@ public enum DateFormatType {
 
 /// The time zone to be used for date conversion
 public enum TimeZoneType {
-    case local, default, utc
+    case local, `default`, utc
     var timeZone:TimeZone {
         switch self {
         case .local: return NSTimeZone.local

--- a/Sources/DateHelper.swift
+++ b/Sources/DateHelper.swift
@@ -616,10 +616,11 @@ public enum DateFormatType {
 
 /// The time zone to be used for date conversion
 public enum TimeZoneType {
-    case local, utc
+    case local, default, utc
     var timeZone:TimeZone {
         switch self {
         case .local: return NSTimeZone.local
+        case .default: return NSTimeZone.default
         case .utc: return TimeZone(secondsFromGMT: 0)!
         }
     }


### PR DESCRIPTION
Since NSTimeZone.local can ben different from NSTimeZone.default, when NSTimeZone.default is changed for an application, the AFDateHelper isn't able to work with the new timezone. This PR fix this issue by adding a new option to the TimeZoneType enum called "default".