### PR TITLE
fixes endOfWeek for weeks not starting on sunday

### DIFF
--- a/Sources/DateHelper.swift
+++ b/Sources/DateHelper.swift
@@ -367,7 +367,8 @@ public extension Date {
         case .startOfWeek:
             return calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: self))!
         case .endOfWeek:
-            let offset = 7 - component(.weekday)!
+            let weekdayOffset = calendar.firstWeekday - 1
+            let offset = 7 - (component(.weekday)! - weekdayOffset)
             return adjust(.day, offset: offset)
         case .startOfMonth:
             return adjust(hour: 0, minute: 0, second: 0, day: 1)


### PR DESCRIPTION
## Old Logic

```swift
let offset = 7 - component(.weekday)!
return adjust(.day, offset: offset)
```

Assume it is Friday and the week starts on a Monday (weekDay = 2), this means that Friday is weekday 6.
> (This issue that this pull request fixes can potentially also be fixed on the components(.weekday) side!)

Following that Friday is weekday 6, we get this:
`offset = 7 - 6 = 1`
then
`return adjust(.day, offset: offset)` will return a date that is within Saturday (which if Sunday is the beginning of the week it makes sense).
However the Calendar.current starts on Monday for my device, this is why `firstWeekday` is 2 and Sunday should be the end of the week.

## New Logic (fixes)

```swift
let weekdayOffset = calendar.firstWeekday - 1
let offset = 7 - (component(.weekday)! - weekdayOffset)
return adjust(.day, offset: offset)
```

What I suggest is creating a `weekdayOffset` constant that takes the calendar's `firstWeekday` and subtracts 1 by it. If the week starts on Sunday, this will always be 0, if the week starts on Monday, this will be 1, etc.

So let's assume the same situation: Today is Friday (weekday = 6) and the week starts on Monday (weekday = 2).
Then `weekdayOffset` will be 1, `offset = 7 - (6-1) = 2` and it will correctly adjust the date for 2 days making it somewhere within Sunday.

While if it is Sunday, the `weekdayOffset` will be 0 and it determines the end of the week correctly. This also works for Tuesday - Saturday accordingly.

## Conclusion

Either this fixes the logic, or the `components(.weekday)` need to be adjusted for the correct `firstWeekday`.