### PR TITLE
Fix the 12 hour format based on current Locale

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/DateHelper.swift
+++ b/Sources/DateHelper.swift
@@ -122,6 +122,7 @@ public extension Date {
         return formatter.string(from: self)
     }
     
+    /// Converts to ISO format using the new API
     @available(iOS 11.0, watchOS 3, tvOS 10, macOS 13, *)
     func formatIsoDate(format: DateFormatType, timeZone: TimeZoneType = .local) -> String {
         let formatter = ISO8601DateFormatter()

--- a/Sources/DateHelper.swift
+++ b/Sources/DateHelper.swift
@@ -101,6 +101,8 @@ public extension Date {
     
     /// Converts the date to string based on a date format, optional timezone and optional locale.
     func toString(format: DateFormatType, timeZone: TimeZoneType = .local, locale: Locale = Locale.current) -> String {
+        var useLocale = locale
+        
         switch format {
         case .dotNet:
             let offset = Foundation.NSTimeZone.default.secondsFromGMT() / 3600
@@ -108,14 +110,19 @@ public extension Date {
             return String(format: format.stringFormat, nowMillis, offset)
         case .isoDateTimeMilliSec, .isoDateTimeSec, .isoDateTime,
              .isoYear,. isoDate, .isoYearMonth:
-            return formatIsoDate(format: format, timeZone: timeZone)
+            if #available(iOS 11.0, watchOS 3, tvOS 10, macOS 13, *) {
+                return formatIsoDate(format: format, timeZone: timeZone)
+            } else {
+                useLocale = Locale(identifier: "en_US_POSIX")
+            }
         default:
             break
         }
-        let formatter = Date.cachedDateFormatters.cachedFormatter(format.stringFormat, timeZone: timeZone.timeZone, locale: locale)
+        let formatter = Date.cachedDateFormatters.cachedFormatter(format.stringFormat, timeZone: timeZone.timeZone, locale: useLocale)
         return formatter.string(from: self)
     }
     
+    @available(iOS 11.0, watchOS 3, tvOS 10, macOS 13, *)
     func formatIsoDate(format: DateFormatType, timeZone: TimeZoneType = .local) -> String {
         let formatter = ISO8601DateFormatter()
         formatter.timeZone = timeZone.timeZone

--- a/Sources/DateHelper.swift
+++ b/Sources/DateHelper.swift
@@ -106,10 +106,37 @@ public extension Date {
             let offset = Foundation.NSTimeZone.default.secondsFromGMT() / 3600
             let nowMillis = 1000 * self.timeIntervalSince1970
             return String(format: format.stringFormat, nowMillis, offset)
+        case .isoDateTimeMilliSec, .isoDateTimeSec, .isoDateTime,
+             .isoYear,. isoDate, .isoYearMonth:
+            return formatIsoDate(format: format, timeZone: timeZone)
         default:
             break
         }
         let formatter = Date.cachedDateFormatters.cachedFormatter(format.stringFormat, timeZone: timeZone.timeZone, locale: locale)
+        return formatter.string(from: self)
+    }
+    
+    func formatIsoDate(format: DateFormatType, timeZone: TimeZoneType = .local) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = timeZone.timeZone
+        
+        var options: ISO8601DateFormatter.Options = []
+        switch format {
+        case .isoDate:
+            options = [.withFullDate]
+        case .isoYearMonth:
+            options = [.withYear, .withMonth]
+        case .isoYear:
+            options = [.withYear]
+        case .isoDateTimeSec, .isoDateTime:
+            options = [.withInternetDateTime]
+        case .isoDateTimeMilliSec:
+            options = [.withInternetDateTime, .withFractionalSeconds]
+        default:
+            fatalError("Unimplemented format \(format)")
+        }
+        
+        formatter.formatOptions = options
         return formatter.string(from: self)
     }
     


### PR DESCRIPTION
For iso formats, the `Locale.current` don't works as expected, if the user set the device for a AM/PM based hour this will return a:

``4:00`` instead a ``16:00``, Apple assumes that's it's the correct behaviour for `NSDateFormat`, see [this](https://forums.developer.apple.com/thread/106031#322269)

I have implemented the Apple recommendation, using the `ISO8601DateFormatter` class and setting the locale to `en_US_POSIX` as fallback for previous system versions