### PR TITLE
Increased minimum watchOS version for ISO Date

### DIFF
--- a/Sources/DateHelper.swift
+++ b/Sources/DateHelper.swift
@@ -121,7 +121,7 @@ public extension Date {
             return String(format: format.stringFormat, nowMillis, offset)
         case .isoDateTimeMilliSec, .isoDateTimeSec, .isoDateTime,
              .isoYear,. isoDate, .isoYearMonth:
-            if #available(iOS 11.0, watchOS 3, tvOS 10, macOS 13, *) {
+            if #available(iOS 11.0, watchOS 4, tvOS 10, macOS 13, *) {
                 return formatIsoDate(format: format, timeZone: timeZone)
             } else {
                 useLocale = Locale(identifier: "en_US_POSIX")
@@ -134,7 +134,7 @@ public extension Date {
     }
     
     /// Converts to ISO format using the new API
-    @available(iOS 11.0, watchOS 3, tvOS 10, macOS 13, *)
+    @available(iOS 11.0, watchOS 4, tvOS 10, macOS 13, *)
     func formatIsoDate(format: DateFormatType, timeZone: TimeZoneType = .local) -> String {
         let formatter = ISO8601DateFormatter()
         formatter.timeZone = timeZone.timeZone


### PR DESCRIPTION
Hello. Thanks for this useful package. When trying to use this package on my watchOS project, I ran into a build error: 

<img width="700" alt="Screen Shot 2021-03-01 at 16 35 47" src="https://user-images.githubusercontent.com/34488374/109638643-4e422780-7b5f-11eb-9a42-f04b514b4655.png">

I fixed this by increasing the availability version for formatting the ISO Date from 3 to 4 for watchOS.