### PR TITLE
exclude Info.plist so Xcode 12.5 stops complaining

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,10 @@ let package = Package(
     targets: [
         .target(
             name: "DateHelper",
-            path: "Sources"
+            path: "Sources",
+            exclude: [
+                "Info.plist"
+            ]
         )
     ],
     swiftLanguageVersions: [.v5]


### PR DESCRIPTION
_(per the issue reported by @atticus here: https://github.com/melvitax/DateHelper/issues/105#issue-865457197)_

Not sure if others are experiencing this issue, but Xcode 12.5 (12E262) throws a warning on every build that it "found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target". User @atticus reported this issue and I believe this fixes it.