### PR TITLE
Fix startOfYear and endOfYear calculation

### DIFF
--- a/Sources/DateHelper.swift
+++ b/Sources/DateHelper.swift
@@ -504,18 +504,14 @@ public extension Date {
             let hours = (component(.hour)! + nearest/2) / nearest * nearest
             return adjust(hour: hours, minute: 0, second: nil)
         case .startOfYear:
-            let month = Date().component(.month)!-1
-            let day = Date().component(.day)!-1
-            return Date()
-                .adjust(.month, offset: -(month))
-                .adjust(.day, offset: -(day))
+            let year = component(.year)!
+            let date = Date(fromString: "\(year)-01-01", format: .isoDate)!
+            return date
                 .adjust(hour: 0, minute: 0, second: 0)
         case .endOfYear:
-            let month = Date().component(.month)!
-            let day = Date().component(.day)!
-            return Date()
-                .adjust(.month, offset: 12-month)
-                .adjust(.day, offset: 31-day)
+            let year = component(.year)!
+            let date = Date(fromString: "\(year)-12-31", format: .isoDate)!
+            return date
                 .adjust(hour: 23, minute: 59, second: 59)
         }
     }


### PR DESCRIPTION
## Description

Fix `startOfYear` and `endOfYear` calculation.
The two types is calculated base on current date instead of the date itself.

In this example the output should be 2023 instead of 2021
```swift
let now = Date() // 2021/08/21
let year = now
    .adjust(.year, offset: 2)
    .dateFor(.endOfYear, calendar: calendar)
    .component(.year)
```
### Changes

- Update `startOfYear` and `endOfYear` calculation to base on the date.