### PR TITLE
Feat/nanosecond precision

### DIFF
--- a/Sources/DateHelper/DateHelper.swift
+++ b/Sources/DateHelper/DateHelper.swift
@@ -301,13 +301,14 @@ public extension Date {
     }
 
     /// Sets a new value to the specified component and returns as a new date
-    func adjust(hour: Int? = nil, minute: Int? = nil, second: Int? = nil, day: Int? = nil, month: Int? = nil) -> Date? {
+    func adjust(hour: Int? = nil, minute: Int? = nil, second: Int? = nil, nanosecond: Int? = nil, day: Int? = nil, month: Int? = nil) -> Date? {
         var comp = Date.components(self)
         comp.month = month ?? comp.month
         comp.day = day ?? comp.day
         comp.hour = hour ?? comp.hour
         comp.minute = minute ?? comp.minute
         comp.second = second ?? comp.second
+        comp.nanosecond = nanosecond ?? comp.nanosecond
         return Calendar.current.date(from: comp)
     }
 

--- a/Sources/DateHelper/DateHelper.swift
+++ b/Sources/DateHelper/DateHelper.swift
@@ -320,7 +320,7 @@ public extension Date {
         case .startOfDay:
             return adjust(hour: 0, minute: 0, second: 0)
         case .endOfDay:
-            return adjust(hour: 23, minute: 59, second: 59)
+            return adjust(hour: 23, minute: 59, second: 59, nanosecond: 999_000_000) // 23:59:59:999
         case .startOfWeek:
             return calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear, .hour, .minute, .second, .nanosecond], from: self))
         case .endOfWeek:

--- a/Tests/DateHelperTests/DateAdjustingTests.swift
+++ b/Tests/DateHelperTests/DateAdjustingTests.swift
@@ -105,7 +105,7 @@ final class DateHelperAdjustingTests: XCTestCase {
     func testDateAdjustEndOfDay() throws {
         guard let original = Calendar.current.date(from: DateComponents(year: 2009, month: 12, day: 06, hour: 18, minute: 14, second: 41)),
               let adjusted = original.adjust(for: .endOfDay),
-              let comparison = Calendar.current.date(from: DateComponents(year: 2009, month: 12, day: 06, hour: 23, minute: 59, second: 59)) else {
+              let comparison = Calendar.current.date(from: DateComponents(year: 2009, month: 12, day: 06, hour: 23, minute: 59, second: 59, nanosecond: 999_000_000)) else {
           return
         }
         XCTAssertEqual(adjusted, comparison)


### PR DESCRIPTION
### Description

This pull request introduces two enhancements to improve time manipulation in the project.

- Added support for adjusting time with nanosecond precision.
- Updated the `endOfDay` to set the time to 23:59:59:999