### PR TITLE
Fix `toString(style:)` for `.month`, `.shortMonth` and `.veryShortMonth`

### DIFF
--- a/Sources/DateHelper/DateHelper.swift
+++ b/Sources/DateHelper/DateHelper.swift
@@ -82,6 +82,12 @@ public extension Date {
             if let day = component(.day) as NSNumber? {
                 return formatter?.string(from: day)
             }
+        case .month:
+            return self.toString(format: .custom("MMMM"))
+        case .shortMonth:
+            return self.toString(format: .custom("MMM"))
+        case .veryShortMonth:
+            return self.toString(format: .custom("MMMMM"))
         default:
             if let symbols = Date.cachedDateFormatters.cachedFormatter()?.symbols(for: style),
                 let weekday = component(.weekday) {


### PR DESCRIPTION
When converting Date to String using predefined month styles, the function is returning incorrect values.

```swift
let date = Date() // 26/3/2024

date.toString(style: .month) // April
date.toString(style: .shortMonth) // Apr
date.toString(style: .veryShortMonth) // A
``` 

I fixed it with `.toString(format: .custom(String))` for each case.